### PR TITLE
optionally supply dict for `use` and `include` functions

### DIFF
--- a/solid2/core/scad_import.py
+++ b/solid2/core/scad_import.py
@@ -99,11 +99,15 @@ def get_callers_namespace_dict(depth=2):
 
         return frame.f_globals
 
-def use(filename, skip_render=False):
-    load_scad_file_or_dir_into_dict(filename, get_callers_namespace_dict(), True, skip_render)
+def use(filename, skip_render=False, to_dict: Optional[dict]=None):
+    if to_dict is None:
+        to_dict = get_callers_namespace_dict()
+    load_scad_file_or_dir_into_dict(filename, to_dict, True, skip_render)
 
-def include(filename, skip_render=False):
-    load_scad_file_or_dir_into_dict(filename, get_callers_namespace_dict(), False, skip_render)
+def include(filename, skip_render=False, to_dict: Optional[dict]=None):
+    if to_dict is None:
+        to_dict = get_callers_namespace_dict()
+    load_scad_file_or_dir_into_dict(filename, to_dict, False, skip_render)
 
 def import_scad(filename, dest_namespace=None, use_not_include=True, skip_render=False):
     if dest_namespace == None:


### PR DESCRIPTION
I've found this useful.

Here's an example of how I used it to import and use the polygears library:

```python
class PolyGears:
    # TODO: add my centering

    scad = dict()
    use("/gk/shapes/PolyGear/PolyGear.scad", to_dict=scad)
    _PGDemo = scad['PGDemo']
    _spur_gear = scad['spur_gear']
    _bevel_gear = scad['bevel_gear']
    _bevel_pair = scad['bevel_pair']
    _constant = scad['constant']
    _zerol = scad['zerol']
    _spiral = scad['spiral']
    _herringbone = scad['herringbone']


    def spur_gear(
            self,
            # basic options
            n=16,  # number of teeth
            m=1.0,  # module
            h=1.0,  # thickness
            pressure_angle=20.0,
            helix_angle: list[float]|float=0.0,  # the sign gives the handiness, can be a list
            backlash=0.1,  # in module units
            # shortcuts
            w=None,  # overrides z when defined
            a0=None,  # overrides pressure angle when defined
            b0=None,  # overrides helix angle when defined
            tol=None,  # overrides backlash
            # advanced options
            chamfer=0.0,  # degrees, should be in [0:90[
            chamfer_shift=0.0,  # from the pitch radius in module units
            add=0,  # add to addendum
            ded=0,  # subtract to the dedendum
            x=0,  # profile shift
            type=1,  # -1: internal 1: external. In practice it flips the sing of the profile shift

            # finesse options
            # fn=5,  # tooth profile subdivisions
            # TODO: get FN, etc. working, and figure them out
            # mine
            center=shapes.CC,
            exz=0.0,
            extend_up=0.0,
            extend_down=0.0,
    ):
        extend_up = extend_up or exz / 2
        extend_down = extend_down or exz / 2
        h += extend_up + extend_down
        it = self._spur_gear(
            n, m, h, pressure_angle, helix_angle, backlash, w, a0, b0, tol, chamfer,
            chamfer_shift, add, ded, x, type
        )
        it = up(h/2)(it)
        return shapes.vcenter(thing_at_top=it, h=h, extend_down=extend_down, center=center)

    def bevel_gear(
            self,
            # basic options
            n=16,  # number of teeth
            m=1,  # module
            w=1,  # tooth width
            cone_angle=45,
            pressure_angle=20,
            helix_angle=0,  # the sign gives the handiness
            backlash=0.1,  # in module units
            # shortcuts
            h=None,  # gear thickness, overrides w when defined
            a0=None,  # overrides pressure angle when defined
            b0=None,  # overrides helix angle when defined
            tol=None,  # overrides backlash
            # advanced options
            add=0,  # add to addendum
            ded=0,  # subtract to the dedendum
            x=0,  # profile shift
            type=1,  # -1: internal 1: external. In practice it flips the sing of the profile shift
            # finesse options
            fn=5,  # tooth profile subdivisions
    ):
        return self._bevel_gear(
            n, m, w, cone_angle, pressure_angle, helix_angle, backlash, h, a0, b0, tol, add, ded, x, type, fn
        )

    def bevel_pair(
            self,
            # basic options
            n1=16,  # number of teeth
            n2=16,  # number of teeth
            m=1,  # module
            w=1,  # tooth width
            axis_angle=90,
            pressure_angle=0,
            helix_angle=0,  # the sign gives the handiness
            backlash=0.1,  # in module units
            only=0,  # build only gear 1 or 2 (0 for both)
            # shortcuts
            a0=None,  # overrides pressure angle when defined
            b0=None,  # overrides helix angle when defined
            tol=None,  # overrides backlash
            # advanced options
            add=0,  # add to addendum
            ded=0,  # subtract to the dedendum
            x=0,  # profile shift
            type=1,  # -1: internal 1: external. In practice it flips the sing of the profile shift
            # finesse options
            fn=5,  # tooth profile subdivisions
    ):
        return self._bevel_pair(
            n1, n2, m, w, axis_angle, pressure_angle, helix_angle, backlash, only, a0, b0, tol, add, ded, x, type, fn,
        )

    def wig_wag(self, h=10.0, lh=0.2, cycles=1.0):
        # print('H', h % lh, h / lh)
        assert h % lh < 0.001 or h % lh - lh < .001
        num_steps = ceil(h / lh)
        steps = [180*cycles*(step/num_steps) for step in range(num_steps)]
        # steps = range(0, int(180*cycles), ceil(h / lh))
        return [30 * math.sin(math.radians(s)) for s in steps]

    def demo(self, i=0):
        if i == 0:
            # hlx = [20, 10, 0, -10, -20]
            h = 10
            LH = 0.2
            hlx = [40 * math.sin(math.radians(x)) for x in range(0, 180, ceil(h / LH))]
            return self.spur_gear(w=10, helix_angle=hlx, n=44,)  # chamfer=30, chamfer_shift=-1, )
        if i == 1:
            return self.bevel_gear(w=5, cone_angle=45, helix_angle=self.zerol(60))


def assembly():
    return Display().draw()

    make = part()

    for i in range(10):
        make += left(i*20)(
            cube([20, 20, 20], center=True)
            - cylinder(d=i, h=100, center=True)
        )

    return make

    return Gears().left(marble_color=None)
    return gear_hold_downs()
    return Gears().draw(marbles=True)
    return bolt_hole_test()
    return BaseCase().bottom()
    return JoinCarvedBlockToBigBlock().draw()
    return CarvedBlock().draw()
    return JoinBaseToBigBlock().draw()

```