### PR TITLE
Move bosl2 into extensions

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "solid2/libs/BOSL2"]
-	path = solid2/libs/BOSL2
+	path = solid2/extensions/bosl2/BOSL2
 	url = git@github.com:revarbat/BOSL2.git

--- a/prebuild.py
+++ b/prebuild.py
@@ -10,7 +10,7 @@ import sys
 
 
 def check_bosl2_submodule():
-    canary_file = "./solid2/libs/BOSL2/std.scad"
+    canary_file = "./solid2/extensions/bosl2/BOSL2/std.scad"
     if not os.path.exists(canary_file):
         print(f"Cannot find {canary_file} - probably you have not initalized the BOSL submodule")
         print("You probably need to run 'git submodule init ; git submodule update'")

--- a/solid2/extensions/bosl2/affine.py
+++ b/solid2/extensions/bosl2/affine.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/affine.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/affine.scad'}", use_not_include=False)
 
 class affine2d_identity(_Bosl2Base):
     def __init__(self, **kwargs):

--- a/solid2/extensions/bosl2/attachments.py
+++ b/solid2/extensions/bosl2/attachments.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/attachments.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/attachments.scad'}", use_not_include=False)
 
 _tags = _OpenSCADConstant('_tags')
 _tag = _OpenSCADConstant('_tag')

--- a/solid2/extensions/bosl2/ball_bearings.py
+++ b/solid2/extensions/bosl2/ball_bearings.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/ball_bearings.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/ball_bearings.scad'}", use_not_include=False)
 
 class ball_bearing_info(_Bosl2Base):
     def __init__(self, trade_size=None, **kwargs):

--- a/solid2/extensions/bosl2/beziers.py
+++ b/solid2/extensions/bosl2/beziers.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/beziers.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/beziers.scad'}", use_not_include=False)
 
 _bezier_matrix_table = _OpenSCADConstant('_bezier_matrix_table')
 class bezier_points(_Bosl2Base):

--- a/solid2/extensions/bosl2/bottlecaps.py
+++ b/solid2/extensions/bosl2/bottlecaps.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/bottlecaps.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/bottlecaps.scad'}", use_not_include=False)
 
 _sp_specs = _OpenSCADConstant('_sp_specs')
 _sp_twist = _OpenSCADConstant('_sp_twist')

--- a/solid2/extensions/bosl2/color.py
+++ b/solid2/extensions/bosl2/color.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/color.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/color.scad'}", use_not_include=False)
 
 class hsl(_Bosl2Base):
     def __init__(self, h=None, s=None, l=None, a=None, **kwargs):

--- a/solid2/extensions/bosl2/comparisons.py
+++ b/solid2/extensions/bosl2/comparisons.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/comparisons.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/comparisons.scad'}", use_not_include=False)
 
 class approx(_Bosl2Base):
     def __init__(self, a=None, b=None, eps=None, **kwargs):

--- a/solid2/extensions/bosl2/constants.py
+++ b/solid2/extensions/bosl2/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/constants.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/constants.scad'}", use_not_include=False)
 
 _UNDEF = _OpenSCADConstant('_UNDEF')
 INCH = _OpenSCADConstant('INCH')

--- a/solid2/extensions/bosl2/coords.py
+++ b/solid2/extensions/bosl2/coords.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/coords.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/coords.scad'}", use_not_include=False)
 
 class point2d(_Bosl2Base):
     def __init__(self, p=None, fill=None, **kwargs):

--- a/solid2/extensions/bosl2/cubetruss.py
+++ b/solid2/extensions/bosl2/cubetruss.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/cubetruss.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/cubetruss.scad'}", use_not_include=False)
 
 _cubetruss_size = _OpenSCADConstant('_cubetruss_size')
 _cubetruss_strut_size = _OpenSCADConstant('_cubetruss_strut_size')

--- a/solid2/extensions/bosl2/distributors.py
+++ b/solid2/extensions/bosl2/distributors.py
@@ -4,7 +4,8 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/distributors.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/distributors.scad'}", use_not_include=False)
+
 
 class move_copies(_Bosl2Base):
     def __init__(self, a=None, p=None, **kwargs):

--- a/solid2/extensions/bosl2/drawing.py
+++ b/solid2/extensions/bosl2/drawing.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/drawing.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/drawing.scad'}", use_not_include=False)
 
 class stroke(_Bosl2Base):
     def __init__(self, path=None, width=None, closed=None, endcaps=None, endcap1=None, endcap2=None, joints=None, dots=None, endcap_width=None, endcap_width1=None, endcap_width2=None, joint_width=None, dots_width=None, endcap_length=None, endcap_length1=None, endcap_length2=None, joint_length=None, dots_length=None, endcap_extent=None, endcap_extent1=None, endcap_extent2=None, joint_extent=None, dots_extent=None, endcap_angle=None, endcap_angle1=None, endcap_angle2=None, joint_angle=None, dots_angle=None, endcap_color=None, endcap_color1=None, endcap_color2=None, joint_color=None, dots_color=None, color=None, trim=None, trim1=None, trim2=None, singleton_scale=None, convexity=None, **kwargs):

--- a/solid2/extensions/bosl2/fnliterals.py
+++ b/solid2/extensions/bosl2/fnliterals.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/fnliterals.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/fnliterals.scad'}", use_not_include=False)
 
 class map(_Bosl2Base):
     def __init__(self, func=None, list=None, **kwargs):

--- a/solid2/extensions/bosl2/gears.py
+++ b/solid2/extensions/bosl2/gears.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/gears.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/gears.scad'}", use_not_include=False)
 
 class spur_gear(_Bosl2Base):
     def __init__(self, pitch=None, teeth=None, thickness=None, shaft_diam=None, hide=None, pressure_angle=None, clearance=None, backlash=None, helical=None, slices=None, interior=None, mod=None, anchor=None, spin=None, orient=None, **kwargs):

--- a/solid2/extensions/bosl2/geometry.py
+++ b/solid2/extensions/bosl2/geometry.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/geometry.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/geometry.scad'}", use_not_include=False)
 
 class is_point_on_line(_Bosl2Base):
     def __init__(self, point=None, line=None, bounded=None, eps=None, **kwargs):

--- a/solid2/extensions/bosl2/hinges.py
+++ b/solid2/extensions/bosl2/hinges.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/hinges.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/hinges.scad'}", use_not_include=False)
 
 class knuckle_hinge(_Bosl2Base):
     def __init__(self, length=None, segs=None, offset=None, inner=None, arm_height=None, arm_angle=None, gap=None, seg_ratio=None, knuckle_diam=None, pin_diam=None, fill=None, clear_top=None, round_bot=None, round_top=None, pin_fn=None, clearance=None, tap_depth=None, screw_head=None, screw_tolerance=None, anchor=None, orient=None, spin=None, **kwargs):

--- a/solid2/extensions/bosl2/joiners.py
+++ b/solid2/extensions/bosl2/joiners.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/joiners.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/joiners.scad'}", use_not_include=False)
 
 class half_joiner_clear(_Bosl2Base):
     def __init__(self, l=None, w=None, ang=None, clearance=None, overlap=None, anchor=None, spin=None, orient=None, **kwargs):

--- a/solid2/extensions/bosl2/linalg.py
+++ b/solid2/extensions/bosl2/linalg.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/linalg.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/linalg.scad'}", use_not_include=False)
 
 class is_matrix(_Bosl2Base):
     def __init__(self, A=None, m=None, n=None, square=None, **kwargs):

--- a/solid2/extensions/bosl2/linear_bearings.py
+++ b/solid2/extensions/bosl2/linear_bearings.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/linear_bearings.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/linear_bearings.scad'}", use_not_include=False)
 
 class lmXuu_info(_Bosl2Base):
     def __init__(self, size=None, **kwargs):

--- a/solid2/extensions/bosl2/lists.py
+++ b/solid2/extensions/bosl2/lists.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/lists.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/lists.scad'}", use_not_include=False)
 
 class is_homogeneous(_Bosl2Base):
     def __init__(self, l=None, depth=None, **kwargs):

--- a/solid2/extensions/bosl2/masks2d.py
+++ b/solid2/extensions/bosl2/masks2d.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/masks2d.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/masks2d.scad'}", use_not_include=False)
 
 class mask2d_roundover(_Bosl2Base):
     def __init__(self, r=None, inset=None, excess=None, d=None, anchor=None, spin=None, **kwargs):

--- a/solid2/extensions/bosl2/masks3d.py
+++ b/solid2/extensions/bosl2/masks3d.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/masks3d.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/masks3d.scad'}", use_not_include=False)
 
 class chamfer_edge_mask(_Bosl2Base):
     def __init__(self, l=None, chamfer=None, excess=None, h=None, length=None, height=None, anchor=None, spin=None, orient=None, **kwargs):

--- a/solid2/extensions/bosl2/math.py
+++ b/solid2/extensions/bosl2/math.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/math.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/math.scad'}", use_not_include=False)
 
 PHI = _OpenSCADConstant('PHI')
 EPSILON = _OpenSCADConstant('EPSILON')

--- a/solid2/extensions/bosl2/metric_screws.py
+++ b/solid2/extensions/bosl2/metric_screws.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/metric_screws.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/metric_screws.scad'}", use_not_include=False)
 
 class get_metric_bolt_head_size(_Bosl2Base):
     def __init__(self, size=None, **kwargs):

--- a/solid2/extensions/bosl2/modular_hose.py
+++ b/solid2/extensions/bosl2/modular_hose.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/modular_hose.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/modular_hose.scad'}", use_not_include=False)
 
 _small_end = _OpenSCADConstant('_small_end')
 _big_end = _OpenSCADConstant('_big_end')

--- a/solid2/extensions/bosl2/mutators.py
+++ b/solid2/extensions/bosl2/mutators.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/mutators.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/mutators.scad'}", use_not_include=False)
 
 class bounding_box(_Bosl2Base):
     def __init__(self, excess=None, planar=None, **kwargs):

--- a/solid2/extensions/bosl2/nema_steppers.py
+++ b/solid2/extensions/bosl2/nema_steppers.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/nema_steppers.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/nema_steppers.scad'}", use_not_include=False)
 
 class nema_motor_info(_Bosl2Base):
     def __init__(self, size=None, **kwargs):

--- a/solid2/extensions/bosl2/partitions.py
+++ b/solid2/extensions/bosl2/partitions.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/partitions.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/partitions.scad'}", use_not_include=False)
 
 class half_of(_Bosl2Base):
     def __init__(self, p=None, v=None, cp=None, **kwargs):

--- a/solid2/extensions/bosl2/paths.py
+++ b/solid2/extensions/bosl2/paths.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/paths.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/paths.scad'}", use_not_include=False)
 
 class is_path(_Bosl2Base):
     def __init__(self, list=None, dim=None, fast=None, **kwargs):

--- a/solid2/extensions/bosl2/polyhedra.py
+++ b/solid2/extensions/bosl2/polyhedra.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/polyhedra.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/polyhedra.scad'}", use_not_include=False)
 
 _tribonacci = _OpenSCADConstant('_tribonacci')
 _polyhedra_ = _OpenSCADConstant('_polyhedra_')

--- a/solid2/extensions/bosl2/regions.py
+++ b/solid2/extensions/bosl2/regions.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/regions.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/regions.scad'}", use_not_include=False)
 
 class is_region(_Bosl2Base):
     def __init__(self, x=None, **kwargs):

--- a/solid2/extensions/bosl2/rounding.py
+++ b/solid2/extensions/bosl2/rounding.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/rounding.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/rounding.scad'}", use_not_include=False)
 
 class round_corners(_Bosl2Base):
     def __init__(self, path=None, method=None, radius=None, r=None, cut=None, joint=None, width=None, k=None, closed=None, verbose=None, **kwargs):

--- a/solid2/extensions/bosl2/screw_drive.py
+++ b/solid2/extensions/bosl2/screw_drive.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/screw_drive.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/screw_drive.scad'}", use_not_include=False)
 
 class _phillips_shaft(_Bosl2Base):
     def __init__(self, x=None, **kwargs):

--- a/solid2/extensions/bosl2/screws.py
+++ b/solid2/extensions/bosl2/screws.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/screws.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/screws.scad'}", use_not_include=False)
 
 class _get_spec(_Bosl2Base):
     def __init__(self, spec=None, needtype=None, origin=None, thread=None, head=None, drive=None, drive_size=None, shape=None, thickness=None, **kwargs):

--- a/solid2/extensions/bosl2/shapes2d.py
+++ b/solid2/extensions/bosl2/shapes2d.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/shapes2d.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/shapes2d.scad'}", use_not_include=False)
 
 class square(_Bosl2Base):
     def __init__(self, size=None, center=None, anchor=None, spin=None, **kwargs):

--- a/solid2/extensions/bosl2/shapes3d.py
+++ b/solid2/extensions/bosl2/shapes3d.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/shapes3d.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/shapes3d.scad'}", use_not_include=False)
 
 class cube(_Bosl2Base):
     def __init__(self, size=None, center=None, anchor=None, spin=None, orient=None, **kwargs):

--- a/solid2/extensions/bosl2/skin.py
+++ b/solid2/extensions/bosl2/skin.py
@@ -4,7 +4,8 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/skin.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/skin.scad'}", use_not_include=False)
+
 
 _leadin_ogive = _OpenSCADConstant('_leadin_ogive')
 _leadin_cut = _OpenSCADConstant('_leadin_cut')

--- a/solid2/extensions/bosl2/sliders.py
+++ b/solid2/extensions/bosl2/sliders.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/sliders.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/sliders.scad'}", use_not_include=False)
 
 class slider(_Bosl2Base):
     def __init__(self, l=None, w=None, h=None, base=None, wall=None, ang=None, anchor=None, spin=None, orient=None, **kwargs):

--- a/solid2/extensions/bosl2/strings.py
+++ b/solid2/extensions/bosl2/strings.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/strings.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/strings.scad'}", use_not_include=False)
 
 class substr(_Bosl2Base):
     def __init__(self, str=None, pos=None, len=None, **kwargs):

--- a/solid2/extensions/bosl2/structs.py
+++ b/solid2/extensions/bosl2/structs.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/structs.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/structs.scad'}", use_not_include=False)
 
 class struct_set(_Bosl2Base):
     def __init__(self, struct=None, key=None, value=None, grow=None, **kwargs):

--- a/solid2/extensions/bosl2/threading.py
+++ b/solid2/extensions/bosl2/threading.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/threading.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/threading.scad'}", use_not_include=False)
 
 class threaded_rod(_Bosl2Base):
     def __init__(self, d=None, l=None, pitch=None, left_handed=None, bevel=None, bevel1=None, bevel2=None, starts=None, internal=None, d1=None, d2=None, length=None, h=None, height=None, blunt_start=None, blunt_start1=None, blunt_start2=None, lead_in=None, lead_in1=None, lead_in2=None, lead_in_ang=None, lead_in_ang1=None, lead_in_ang2=None, end_len=None, end_len1=None, end_len2=None, lead_in_shape=None, anchor=None, spin=None, orient=None, **kwargs):

--- a/solid2/extensions/bosl2/transforms.py
+++ b/solid2/extensions/bosl2/transforms.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/transforms.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/transforms.scad'}", use_not_include=False)
 
 _NO_ARG = _OpenSCADConstant('_NO_ARG')
 class move(_Bosl2Base):

--- a/solid2/extensions/bosl2/trigonometry.py
+++ b/solid2/extensions/bosl2/trigonometry.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/trigonometry.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/trigonometry.scad'}", use_not_include=False)
 
 class law_of_cosines(_Bosl2Base):
     def __init__(self, a=None, b=None, c=None, C=None, **kwargs):

--- a/solid2/extensions/bosl2/tripod_mounts.py
+++ b/solid2/extensions/bosl2/tripod_mounts.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/tripod_mounts.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/tripod_mounts.scad'}", use_not_include=False)
 
 class manfrotto_rc2_plate(_Bosl2Base):
     def __init__(self, chamfer=None, anchor=None, orient=None, spin=None, **kwargs):

--- a/solid2/extensions/bosl2/turtle3d.py
+++ b/solid2/extensions/bosl2/turtle3d.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/turtle3d.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/turtle3d.scad'}", use_not_include=False)
 
 class _transpart(_Bosl2Base):
     def __init__(self, T=None, **kwargs):

--- a/solid2/extensions/bosl2/utility.py
+++ b/solid2/extensions/bosl2/utility.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/utility.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/utility.scad'}", use_not_include=False)
 
 class typeof(_Bosl2Base):
     def __init__(self, x=None, **kwargs):

--- a/solid2/extensions/bosl2/vectors.py
+++ b/solid2/extensions/bosl2/vectors.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/vectors.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/vectors.scad'}", use_not_include=False)
 
 class is_vector(_Bosl2Base):
     def __init__(self, v=None, length=None, zero=None, all_nonzero=None, eps=None, **kwargs):

--- a/solid2/extensions/bosl2/version.py
+++ b/solid2/extensions/bosl2/version.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/version.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/version.scad'}", use_not_include=False)
 
 BOSL_VERSION = _OpenSCADConstant('BOSL_VERSION')
 class bosl_version(_Bosl2Base):

--- a/solid2/extensions/bosl2/vnf.py
+++ b/solid2/extensions/bosl2/vnf.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/vnf.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/vnf.scad'}", use_not_include=False)
 
 EMPTY_VNF = _OpenSCADConstant('EMPTY_VNF')
 _vnf_validate_errs = _OpenSCADConstant('_vnf_validate_errs')

--- a/solid2/extensions/bosl2/walls.py
+++ b/solid2/extensions/bosl2/walls.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/walls.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/walls.scad'}", use_not_include=False)
 
 class sparse_wall(_Bosl2Base):
     def __init__(self, h=None, l=None, thick=None, maxang=None, strut=None, max_bridge=None, anchor=None, spin=None, orient=None, **kwargs):

--- a/solid2/extensions/bosl2/wiring.py
+++ b/solid2/extensions/bosl2/wiring.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from .bosl2_base import Bosl2Base as _Bosl2Base
 
-_extra_scad_include(f"{_Path(__file__).parent.parent / '../libs/BOSL2/wiring.scad'}", use_not_include=False)
+_extra_scad_include(f"{_Path(__file__).parent.parent / 'bosl2/BOSL2/wiring.scad'}", use_not_include=False)
 
 class _hex_offset_ring(_Bosl2Base):
     def __init__(self, d=None, lev=None, **kwargs):

--- a/solid2/extensions/bosl2_generator.py
+++ b/solid2/extensions/bosl2_generator.py
@@ -99,7 +99,7 @@ def generateBosl2AccessSyntaxMixin(bosl2_dir, outputDir):
                 continue
             f.write(generateCallable(c))
 
-bosl2_dir = Path("../libs/BOSL2")
+bosl2_dir = Path("./bosl2/BOSL2")
 output_dir = Path(__file__).parent / "bosl2"
 
 makePackage(output_dir)


### PR DESCRIPTION
Move the BOSL2 scad files into extensions/bosl2 instead of libs/

Mentioned in this issue: https://github.com/jeff-dh/SolidPython/issues/21