### PR TITLE
Add ability to run tests on OSX

### DIFF
--- a/test/examples_test.py
+++ b/test/examples_test.py
@@ -1,3 +1,4 @@
+import platform
 import unittest
 import shutil
 import subprocess
@@ -5,17 +6,15 @@ import re
 from pathlib import Path
 
 
-def get_openscad_executable():
-    import platform
-    OPENSCAD_EXECUTABLES = {
-        'Darwin': "/Applications/OpenSCAD.app/Contents/MacOS/OpenSCAD",
-        'Linux': "openscad"
-    }
-    return OPENSCAD_EXECUTABLES[platform.system()]
-
-
 class ExamplesTest(unittest.TestCase):
     def test_examples(self):
+        def get_openscad_executable():
+            OPENSCAD_EXECUTABLES = {
+                'Darwin': "/Applications/OpenSCAD.app/Contents/MacOS/OpenSCAD",
+                'Linux': "openscad"
+            }
+            return OPENSCAD_EXECUTABLES[platform.system()]
+
         root = Path(__file__).parent.parent
 
         for f in sorted(Path(root / "solid2" / "examples/").iterdir()):

--- a/test/examples_test.py
+++ b/test/examples_test.py
@@ -1,8 +1,20 @@
+import platform
 import unittest
 import shutil
 import subprocess
 import re
 from pathlib import Path
+
+
+OPENSCAD_EXECUTABLES = {
+    'Darwin': "/Applications/OpenSCAD.app/Contents/MacOS/OpenSCAD",
+    'Linux': "openscad"
+}
+
+
+def get_openscad_executable():
+    return OPENSCAD_EXECUTABLES[platform.system()]
+
 
 class ExamplesTest(unittest.TestCase):
     def test_examples(self):
@@ -29,7 +41,7 @@ class ExamplesTest(unittest.TestCase):
             # make sure there's no diff
             self.assertEqual(diff.decode(), "")
             # render with openscad
-            subprocess.check_call(["openscad", "-o",
+            subprocess.check_call([get_openscad_executable(), "-o",
                                    test_scad_file.with_suffix(".png"),
                                    "--preview", "-",
                                    test_scad_file],

--- a/test/examples_test.py
+++ b/test/examples_test.py
@@ -1,4 +1,3 @@
-import platform
 import unittest
 import shutil
 import subprocess
@@ -6,13 +5,12 @@ import re
 from pathlib import Path
 
 
-OPENSCAD_EXECUTABLES = {
-    'Darwin': "/Applications/OpenSCAD.app/Contents/MacOS/OpenSCAD",
-    'Linux': "openscad"
-}
-
-
 def get_openscad_executable():
+    import platform
+    OPENSCAD_EXECUTABLES = {
+        'Darwin': "/Applications/OpenSCAD.app/Contents/MacOS/OpenSCAD",
+        'Linux': "openscad"
+    }
     return OPENSCAD_EXECUTABLES[platform.system()]
 
 


### PR DESCRIPTION
Add ability to run tests on OSX, where there generally isn't an 'openscad' executable on PATH