### PR TITLE
Add plugin system for extending SolidPython

### DIFF
--- a/solid2/core/__init__.py
+++ b/solid2/core/__init__.py
@@ -9,3 +9,4 @@ from .scad_import import import_scad, use, include
 
 from .object_base import scad_inline, scad_inline_parameter_func, sin, cos,\
                          tan, asin, acos, atan, sqrt, not_
+from .object_base.access_syntax_mixin import register

--- a/solid2/core/__init__.py
+++ b/solid2/core/__init__.py
@@ -9,4 +9,3 @@ from .scad_import import import_scad, use, include
 
 from .object_base import scad_inline, scad_inline_parameter_func, sin, cos,\
                          tan, asin, acos, atan, sqrt, not_
-from .object_base.access_syntax_mixin import register

--- a/solid2/core/extension_manager.py
+++ b/solid2/core/extension_manager.py
@@ -4,6 +4,7 @@ class ExtensionManager():
         self.wrapper = []
         self.pre_render = []
         self.post_render = []
+        self.access_syntax = {}
 
     def register_root_wrapper(self, ext):
         self.wrapper.append(ext)
@@ -13,6 +14,18 @@ class ExtensionManager():
 
     def register_post_render(self, func):
         self.post_render.append(func)
+
+    def register_access_syntax(self, fn):
+        import inspect
+        if fn.__name__ in self.access_syntax:
+            raise Exception(f'Unable to register "{fn.__name__}" plugin, it '
+                             'would overwrite an existing plugin or method.')
+
+        if inspect.isclass(fn):
+            self.access_syntax[fn.__name__] = \
+                lambda y, *args, **kwargs: fn(*args, **kwargs)(y)
+        else:
+            self.access_syntax[fn.__name__] = fn
 
     def wrap_root_node(self, root):
         new_root_node = root
@@ -36,6 +49,9 @@ class ExtensionManager():
             post_render_str += f(root)
 
         return post_render_str
+
+    def access_syntax_lookup(self, key):
+        return self.access_syntax.get(key, None)
 
 default_extension_manager = ExtensionManager()
 

--- a/solid2/core/object_base/access_syntax_mixin.py
+++ b/solid2/core/object_base/access_syntax_mixin.py
@@ -70,3 +70,12 @@ class AccessSyntaxMixin:
     def root(self):       return builtins().root()(self)
     def disable(self):    return builtins().disable()(self)
 
+    def __getattr__(self, name):
+        #ask the extension manager for dynamic access syntax extensions
+        from ..extension_manager import default_extension_manager
+
+        fn = default_extension_manager.access_syntax_lookup(name)
+        if not fn:
+            raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
+
+        return lambda *args, **kwargs: fn(self, *args, **kwargs)

--- a/solid2/core/object_base/access_syntax_mixin.py
+++ b/solid2/core/object_base/access_syntax_mixin.py
@@ -1,13 +1,10 @@
 from ...config import config
 
-
 def builtins():
     from .. import builtins
     return builtins
 
 class AccessSyntaxMixin:
-    plugins = {}
-
     if not config.use_implicit_builtins:
         def intersection_for(self, n):     return builtins().intersection_for(n)(self)
         def color(self, color, alpha=1.0): return builtins().color(color, alpha)(self)
@@ -73,19 +70,3 @@ class AccessSyntaxMixin:
     def root(self):       return builtins().root()(self)
     def disable(self):    return builtins().disable()(self)
 
-    def __getattr__(self, name):
-        if name in self.plugins:
-            # should we check that plugin returned a builtin type?
-            return lambda *args, **kwargs: self.plugins[name](self, *args, **kwargs)
-        raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
-
-def register(plugins):
-    # allow specifying a single plugin or a dictionary of plugins
-    if not isinstance(plugins, dict):
-        plugins = {plugins.__name__: plugins}
-
-    # register each plugin
-    for name in plugins:
-        if name in AccessSyntaxMixin.plugins or hasattr(AccessSyntaxMixin, name):
-            raise Exception(f'Unable to register "{name}" plugin, it would overwrite an existing plugin or method.')
-        AccessSyntaxMixin.plugins[name] = plugins[name]

--- a/solid2/core/object_base/access_syntax_mixin.py
+++ b/solid2/core/object_base/access_syntax_mixin.py
@@ -1,10 +1,13 @@
 from ...config import config
 
+
 def builtins():
     from .. import builtins
     return builtins
 
 class AccessSyntaxMixin:
+    plugins = {}
+
     if not config.use_implicit_builtins:
         def intersection_for(self, n):     return builtins().intersection_for(n)(self)
         def color(self, color, alpha=1.0): return builtins().color(color, alpha)(self)
@@ -70,3 +73,19 @@ class AccessSyntaxMixin:
     def root(self):       return builtins().root()(self)
     def disable(self):    return builtins().disable()(self)
 
+    def __getattr__(self, name):
+        if name in self.plugins:
+            # should we check that plugin returned a builtin type?
+            return lambda *args, **kwargs: self.plugins[name](self, *args, **kwargs)
+        raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
+
+def register(plugins):
+    # allow specifying a single plugin or a dictionary of plugins
+    if not isinstance(plugins, dict):
+        plugins = {plugins.__name__: plugins}
+
+    # register each plugin
+    for name in plugins:
+        if name in AccessSyntaxMixin.plugins or hasattr(AccessSyntaxMixin, name):
+            raise Exception(f'Unable to register "{name}" plugin, it would overwrite an existing plugin or method.')
+        AccessSyntaxMixin.plugins[name] = plugins[name]

--- a/solid2/examples/08-extensions.py
+++ b/solid2/examples/08-extensions.py
@@ -44,11 +44,21 @@ def non_sense_pre_render(root):
 # register the pre render extension.
 from solid2.core.extension_manager import default_extension_manager
 default_extension_manager.register_pre_render(non_sense_pre_render)
+
+# add an access syntax extension
+def leftUp(x):
+    return x.left(1).up(1)
+
+# register the access syntax extension
+default_extension_manager.register_access_syntax(leftUp)
+
+# register red as access syntax extension
+default_extension_manager.register_access_syntax(red)
 # ==============
 
 
-cube1 = cube(10)
-cube2 = cube(5).left(20)
+cube1 = cube(10).red()
+cube2 = cube(5).leftUp()
 
 commented_cube1 = non_sense_comment()(
                       cube1

--- a/tests/examples_scad/08-extensions.scad
+++ b/tests/examples_scad/08-extensions.scad
@@ -6,10 +6,14 @@
 union() {
 	color(c = "red") {
 		//non sense comment
-		cube(size = 10);
+		color(c = "red") {
+			cube(size = 10);
+		}
 	}
 	//non sense comment
-	translate(v = [-20, 0, 0]) {
-		cube(size = 5);
+	translate(v = [0, 0, 1]) {
+		translate(v = [-1, 0, 0]) {
+			cube(size = 5);
+		}
 	}
 }


### PR DESCRIPTION
I am really enjoying solid python!  I hope you consider this proposal, I think it would be really helpful to grow SolidPython.

I thought it would be really nice to have a standard way to extend SolidPython. Often it makes sense to just write a helper function, but sometimes it would be really valuable to add more fundamental functionality and make use of the function chaining.  I initially did this for my own projects via inheritance, but it was difficult and didn't lend itself to breaking functionality out into reusable modules. I think a plugin system would be very convenient and open things up for third party modules.

This pull request creates a simple plugin system.  A plugin would be a function (or collection of functions) that extend the built in shapes with additional chain-able functionality.

Usage example:
```
from solid2 import *

# create a plugin
def shrink(obj):
    return obj.scale(.5, .5, .5)

# register plugin
register(shrink)

# create geometry
geometry = cube(1).shrink().translate(1, 2, 3)

# save to scad file
geometry.save_as_scad()
```

I imagine in a real situation someone would create a package, the package could be installed, and in your app you could register the plugin.  Something like this:
```
from solid2 import *
from plugins import chamfer

# register plugin
register(chamfer)

# create geometry
geometry = cube(1).chamfer().translate(1, 2, 3)

# save to scad file
geometry.save_as_scad()
```