### PR TITLE
Support non-ASCII character

### DIFF
--- a/solid2/core/scad_render.py
+++ b/solid2/core/scad_render.py
@@ -75,7 +75,7 @@ def _write_to_file(out_string, filename=None, outdir=''):
 
     outfile_path = outpath / Path(outfile)
 
-    outfile_path.write_text(out_string)
+    outfile_path.write_text(out_string, encoding="utf-8")
     return outfile_path.absolute().as_posix()
 
 def get_include_string():


### PR DESCRIPTION
To ensure that the text function works with non-ASCII characters, use UTF-8 encoding when writing the text.