### PR TITLE
fix(utils.py): escape backslashes and double quotes in rendered strings

### DIFF
--- a/solid2/core/utils.py
+++ b/solid2/core/utils.py
@@ -1,4 +1,5 @@
 import keyword
+import re
 import textwrap
 from pathlib import Path
 
@@ -57,7 +58,7 @@ def py2openscad(o):
     if type(o) == bool:
         return str(o).lower()
     if type(o) == str:
-        return f'\"{o}\"'  # type: ignore
+        return f'\"{re.sub(r'([\\"])', r'\\\1', o)}\"'  # type: ignore
     if isinstance(o, ObjectBase):
         return o._render()[:-2] #[:-1] removing traling ;\n
     if hasattr(o, "__iter__"):

--- a/solid2/core/utils.py
+++ b/solid2/core/utils.py
@@ -58,7 +58,8 @@ def py2openscad(o):
     if type(o) == bool:
         return str(o).lower()
     if type(o) == str:
-        return f'\"{re.sub(r'([\\"])', r'\\\1', o)}\"'  # type: ignore
+        escaped_str = re.sub(r'([\\"])', r'\\\1', o)
+        return f'\"{escaped_str}\"'  # type: ignore
     if isinstance(o, ObjectBase):
         return o._render()[:-2] #[:-1] removing traling ;\n
     if hasattr(o, "__iter__"):


### PR DESCRIPTION
Fixes #68.